### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/src/Cake.MSBuildTask/Cake.MSBuildTask.csproj
+++ b/src/Cake.MSBuildTask/Cake.MSBuildTask.csproj
@@ -40,13 +40,13 @@
     <DocumentationFile>bin\Release\Cake.MSBuildTask.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Common">
-      <HintPath>..\..\tools\Cake\Cake.Common.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Cake.Common, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Common.0.17.0\lib\net45\Cake.Common.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Cake.Core">
-      <HintPath>..\..\tools\Cake\Cake.Core.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Framework">
       <Private>True</Private>
@@ -73,6 +73,9 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/Cake.MSBuildTask/packages.config
+++ b/src/Cake.MSBuildTask/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Cake.Common" version="0.17.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.